### PR TITLE
Placeholder endpoints for coordinated mining

### DIFF
--- a/apps/arweave/src/ar_coordination.erl
+++ b/apps/arweave/src/ar_coordination.erl
@@ -10,8 +10,8 @@
 -include_lib("arweave/include/ar_config.hrl").
 
 -record(state, {
-    mining_peers = #{},
-	peers = []
+    peers_by_partition = #{},
+	peer_list = []
 }).
 
 %%%===================================================================
@@ -53,7 +53,7 @@ init([]) ->
 handle_call(get_peers, _From, State) ->
 	{reply, {ok, State}, State};
 handle_call({is_peer, Peer}, _From, State) ->
-	IsPeer = lists:member(Peer, State#state.peers),
+	IsPeer = lists:member(Peer, State#state.peer_list),
 	{reply, IsPeer, State};
 handle_call(Request, _From, State) ->
 	?LOG_WARNING("event: unhandled_call, request: ~p", [Request]),
@@ -75,7 +75,7 @@ terminate(_Reason, _State) ->
 %%%===================================================================
 
 add_mining_peer({Peer, StorageModules}, State) ->
-	Peers = State#state.peers,
+	Peers = State#state.peer_list,
     MiningPeers =
         lists:foldl(
 			fun	({PartitionSize, PartitionId, Packing}, Acc) ->
@@ -87,7 +87,7 @@ add_mining_peer({Peer, StorageModules}, State) ->
 				        maps:put(PartitionId, [{Peer, PartitionSize, Packing}], Acc)
                 end
 			end,
-			State#state.mining_peers,
+			State#state.peers_by_partition,
             StorageModules
 		),
-    State#state{mining_peers = MiningPeers, peers = [Peer | Peers]}.
+    State#state{peers_by_partition = MiningPeers, peer_list = [Peer | Peers]}.

--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -1193,6 +1193,16 @@ handle(<<"POST">>, [<<"vdf">>], Req, Pid) ->
 			handle_post_vdf(Req, Pid)
 	end;
 
+%% TODO: endpoint description
+%% POST request to endpoint /mining/h1
+handle(<<"POST">>, [<<"mining">>, <<"h1">>], Req, Pid) ->
+	case ar_node:is_joined() of
+		false ->
+			not_joined(Req);
+		true ->
+			handle_mining_h1(Req, Pid)
+	end;
+
 %% Catch case for requests made to unknown endpoints.
 %% Returns error code 400 - Request type not found.
 handle(_, _, Req, _Pid) ->
@@ -2687,3 +2697,27 @@ read_body_chunk(Req, Pid, Size, Timeout) ->
 				{path, cowboy_req:path(Req)}, {peer, ar_util:format_peer(Peer)}]),
 		{error, timeout}
 	end.
+
+handle_mining_h1(Req, Pid) ->
+	Peer = ar_http_util:arweave_peer(Req),
+	case is_mining_peer(Peer) of
+		false ->
+			{403, #{}, <<>>, Req};
+		true ->
+			case read_complete_body(Req, Pid) of
+				{ok, Body, Req2} ->
+					case ar_serialize:json_decode(Body, [{return_maps, true}]) of
+						{ok, JSON} ->
+							H2Materials = ar_serialize:json_map_to_h2_materials(JSON),
+							ar:console("H2 Materials ~p~n", [H2Materials]),
+							{200, #{}, <<>>, Req};
+						{error, _} ->
+							{400, #{}, jiffy:encode(#{ error => invalid_json }), Req2}
+					end;
+				{error, body_size_too_large} ->
+					{413, #{}, <<"Payload too large">>, Req}
+			end
+	end.
+
+is_mining_peer(Peer) ->
+	ar_coordination:is_peer(Peer).

--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -1203,6 +1203,16 @@ handle(<<"POST">>, [<<"mining">>, <<"h1">>], Req, Pid) ->
 			handle_mining_h1(Req, Pid)
 	end;
 
+%% TODO: endpoint description
+%% POST request to endpoint /mining/h1
+handle(<<"POST">>, [<<"mining">>, <<"h2">>], Req, Pid) ->
+	case ar_node:is_joined() of
+		false ->
+			not_joined(Req);
+		true ->
+			handle_mining_h2(Req, Pid)
+	end;
+
 %% Catch case for requests made to unknown endpoints.
 %% Returns error code 400 - Request type not found.
 handle(_, _, Req, _Pid) ->
@@ -2721,3 +2731,24 @@ handle_mining_h1(Req, Pid) ->
 
 is_mining_peer(Peer) ->
 	ar_coordination:is_peer(Peer).
+
+handle_mining_h2(Req, Pid) ->
+	Peer = ar_http_util:arweave_peer(Req),
+	case is_mining_peer(Peer) of
+		false ->
+			{403, #{}, <<>>, Req};
+		true ->
+			case read_complete_body(Req, Pid) of
+				{ok, Body, Req2} ->
+					case ar_serialize:json_decode(Body, [{return_maps, true}]) of
+						{ok, JSON} ->
+							Solution = ar_serialize:json_map_to_solutions(JSON),
+							ar:console("Possible solution ~p~n", [Solution]),
+							{200, #{}, <<>>, Req};
+						{error, _} ->
+							{400, #{}, jiffy:encode(#{ error => invalid_json }), Req2}
+					end;
+				{error, body_size_too_large} ->
+					{413, #{}, <<"Payload too large">>, Req}
+			end
+	end.

--- a/apps/arweave/src/ar_serialize.erl
+++ b/apps/arweave/src/ar_serialize.erl
@@ -19,7 +19,8 @@
 		encode_bin_list/3, signature_type_to_binary/1, binary_to_signature_type/1,
 		price_history_to_binary/1, binary_to_price_history/1,
 		nonce_limiter_update_to_binary/1, binary_to_nonce_limiter_update/1,
-		nonce_limiter_update_response_to_binary/1, binary_to_nonce_limiter_update_response/1]).
+		nonce_limiter_update_response_to_binary/1, binary_to_nonce_limiter_update_response/1,
+		json_map_to_h2_materials/1]).
 
 -include_lib("arweave/include/ar.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -1419,6 +1420,15 @@ binary_to_signature_type(List) ->
 		%% For backwards-compatibility.
 		_ -> {?RSA_SIGN_ALG, 65537}
 	end.
+
+json_map_to_h2_materials(JSON) ->
+	lists:map(fun (JsonElement) ->
+		#{
+			h0 => ar_util:decode(maps:get(<<"h0">>, JsonElement)),
+			h1 => ar_util:decode(maps:get(<<"h1">>, JsonElement)),
+			recall_bytes_2 => ar_util:decode(maps:get(<<"recall_bytes_2">>, JsonElement))
+		}
+	end, JSON).
 
 %%% Tests: ar_serialize
 

--- a/apps/arweave/src/ar_serialize.erl
+++ b/apps/arweave/src/ar_serialize.erl
@@ -20,7 +20,7 @@
 		price_history_to_binary/1, binary_to_price_history/1,
 		nonce_limiter_update_to_binary/1, binary_to_nonce_limiter_update/1,
 		nonce_limiter_update_response_to_binary/1, binary_to_nonce_limiter_update_response/1,
-		json_map_to_h2_materials/1]).
+		json_map_to_h2_materials/1, json_map_to_solutions/1]).
 
 -include_lib("arweave/include/ar.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -1427,6 +1427,17 @@ json_map_to_h2_materials(JSON) ->
 			h0 => ar_util:decode(maps:get(<<"h0">>, JsonElement)),
 			h1 => ar_util:decode(maps:get(<<"h1">>, JsonElement)),
 			recall_bytes_2 => ar_util:decode(maps:get(<<"recall_bytes_2">>, JsonElement))
+		}
+	end, JSON).
+
+json_map_to_solutions(JSON) ->
+	lists:map(fun (JsonElement) ->
+		#{
+			h0 => ar_util:decode(maps:get(<<"h0">>, JsonElement)),
+			h1 => ar_util:decode(maps:get(<<"h1">>, JsonElement)),
+			h2 => ar_util:decode(maps:get(<<"h2">>, JsonElement)),
+			pre_image => ar_util:decode(maps:get(<<"pre_image">>, JsonElement)),
+			chunk_2 => ar_util:decode(maps:get(<<"chunk_2">>, JsonElement))
 		}
 	end, JSON).
 


### PR DESCRIPTION
- Add `peers` to `ar_coordination` for lookup on coordinated mining endpoints
- `POST /mining/h1` endpoint 
- `POST /mining/h2` endpoint

For now both endpoints just decode the payload and print it to console

Example payload `/mining/h1`

```json
[
    {
        "h0": "cGFyYW0gaDA=",
        "h1": "cGFyYW0gaDE=",
        "recall_bytes_2": "cGFyYW0gcmVjYWxsX2J5dGVzXzI="
    }
]
```

Example payload `/mining/h2`

```json
[
    {
        "h0": "cGFyYW0gaDA=",
        "h1": "cGFyYW0gaDE=",
        "h2": "cGFyYW0gaDI=",
        "pre_image": "cGFyYW0gcHJlX2ltYWdl",
        "chunk_2": "cGFyYW0gY2h1bmtfMg=="
    }
]
```